### PR TITLE
fix: remove optional peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,6 @@
         "antd": "4",
         "rc-resize-observer": "*"
     },
-    "peerDependenciesMeta": {
-        "rc-resize-observer": {
-            "optional": true
-        }
-    },
     "devDependencies": {
         "@swc/core": "^1.3.58",
         "@swc/jest": "^0.2.26",


### PR DESCRIPTION
修复 `rc-resize-observer` 依赖未找到