### PR TITLE
fix: query visible popup element only

### DIFF
--- a/src/autoComplete/__tests__/autoComplete.test.tsx
+++ b/src/autoComplete/__tests__/autoComplete.test.tsx
@@ -33,6 +33,27 @@ describe('Test Select fire functions', () => {
     });
 
     /**
+     * @link queryDropdown
+     */
+    test('queryDropdown', () => {
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        const { container } = render(
+            <>
+                <AutoComplete options={[{ label: '1', value: '1' }]} onSelect={fn1} />
+                <AutoComplete options={[{ label: '2', value: '2' }]} onSelect={fn2} />
+            </>
+        );
+        autoComplete.fireOpen(autoComplete.querySelector(container)!);
+        autoComplete.fireSelect(autoComplete.queryDropdown(document)!, 0);
+        expect(fn1).toBeCalledWith('1', expect.objectContaining({ label: '1', value: '1' }));
+
+        autoComplete.fireOpen(autoComplete.querySelector(container, 1)!);
+        autoComplete.fireSelect(autoComplete.queryDropdown(document)!, 0);
+        expect(fn2).toBeCalledWith('2', expect.objectContaining({ label: '2', value: '2' }));
+    });
+
+    /**
      * @link queryOption
      */
     test('queryOption', () => {

--- a/src/autoComplete/index.ts
+++ b/src/autoComplete/index.ts
@@ -71,6 +71,17 @@ export function querySelector(container: IContainer, index = 0) {
 }
 
 /**
+ * Returns the Select Dropdown which is not hidden
+ */
+export function queryDropdown(container: IContainer) {
+    const selector = `.${getProvider('prefixCls')}-select-dropdown:not(.${getProvider(
+        'prefixCls'
+    )}-select-dropdown-hidden)`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector);
+    return ele;
+}
+
+/**
  * Returns option element of AutoComplete
  */
 export function queryOption(container: IContainer, index = 0) {

--- a/src/cascader/__tests__/cascader.test.tsx
+++ b/src/cascader/__tests__/cascader.test.tsx
@@ -185,7 +185,7 @@ describe("Test Cascader's fire functions", () => {
         expect(fn2).toBeCalledTimes(0);
 
         cascader.fireOpen(cascader.query(container, 1)!);
-        cascader.fireChange(cascader.queryDropdown(container, 1)!, 0, 0, 0);
+        cascader.fireChange(cascader.queryDropdown(container)!, 0, 0, 0);
         expect(fn1).toBeCalledTimes(1);
         expect(fn2).toBeCalledTimes(1);
     });

--- a/src/cascader/index.ts
+++ b/src/cascader/index.ts
@@ -98,13 +98,14 @@ export function queryInput(container: IContainer, index = 0) {
 }
 
 /**
- * Returns the `index` element of Cascader's Dropdown
+ * Returns the Cascader's Dropdown which is not hidden
  * @notice Be aware of the different parentElement affected by getPopupContainer
- * @param index the order of Cascader's Dropdown, default is `0`
  */
-export function queryDropdown(container: IContainer, index = 0) {
-    const selector = `.${getProvider('prefixCls')}-cascader-dropdown`;
-    const ele = queryViaSelector<HTMLDivElement>(container, selector, index);
+export function queryDropdown(container: IContainer) {
+    const selector = `.${getProvider('prefixCls')}-cascader-dropdown:not(.${getProvider(
+        'prefixCls'
+    )}-select-dropdown-hidden)`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector);
     return ele;
 }
 

--- a/src/datePicker/index.ts
+++ b/src/datePicker/index.ts
@@ -97,13 +97,13 @@ export function queryInput(container: IContainer, index = 0) {
 }
 
 /**
- * Returns the `index` dropdown's container about DatePicker
- * @param index default is `0`
- * @returns
+ * Returns the dropdown of DatePicker which is not hidden
  */
-export function queryDropdown(container: IContainer, index = 0) {
-    const selector = `.${getProvider('prefixCls')}-picker-dropdown`;
-    const ele = queryViaSelector<HTMLDivElement>(container, selector, index);
+export function queryDropdown(container: IContainer) {
+    const selector = `.${getProvider('prefixCls')}-picker-dropdown:not(${getProvider(
+        'prefixCls'
+    )}-picker-dropdown-hidden)`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector);
     return ele;
 }
 

--- a/src/dropdown/index.ts
+++ b/src/dropdown/index.ts
@@ -59,7 +59,9 @@ export function query(container: IContainer, index = 0) {
  * You need open Dropdown first
  */
 export function queryDropdownMenu(container: IContainer) {
-    const selector = `.${getProvider('prefixCls')}-dropdown-menu`;
+    const selector = `.${getProvider('prefixCls')}-dropdown:not(.${getProvider(
+        'prefixCls'
+    )}-dropdown-hidden) .${getProvider('prefixCls')}-dropdown-menu`;
     const ele = queryViaSelector(container, selector);
     return ele;
 }

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -74,8 +74,9 @@ describe('Test Select fire functions', () => {
         select.fireOpen(select.querySelector(container)!);
         select.fireSelect(select.queryDropdown(document)!, 0);
         expect(fn1).toBeCalledWith(1, expect.objectContaining({ label: 1, value: 1 }));
+
         select.fireOpen(select.querySelector(container, 1)!);
-        select.fireSelect(select.queryDropdown(document, 1)!, 0);
+        select.fireSelect(select.queryDropdown(document)!, 0);
         expect(fn2).toBeCalledWith(2, expect.objectContaining({ label: 2, value: 2 }));
     });
 

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -114,12 +114,13 @@ export function querySelector(container: IContainer, index = 0) {
 }
 
 /**
- * Returns the `index` dropdown's container for Select
- * @param index default is 0
+ * Returns the Select Dropdown which is not hidden
  */
-export function queryDropdown(container: IContainer, index = 0) {
-    const selector = `.${getProvider('prefixCls')}-select-dropdown`;
-    const ele = queryViaSelector<HTMLDivElement>(container, selector, index);
+export function queryDropdown(container: IContainer) {
+    const selector = `.${getProvider('prefixCls')}-select-dropdown:not(.${getProvider(
+        'prefixCls'
+    )}-select-dropdown-hidden)`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector);
     return ele;
 }
 

--- a/src/timePicker/index.ts
+++ b/src/timePicker/index.ts
@@ -73,10 +73,10 @@ export function query(container: IContainer, index = 0) {
 }
 
 /**
- * Returns the dropdown element of timePicker
+ * Returns the dropdown of timePicker which is not hidden
  */
-export function queryDropdown(container: IContainer, index = 0) {
-    datePicker.queryDropdown(container, index);
+export function queryDropdown(container: IContainer) {
+    datePicker.queryDropdown(container);
 }
 
 /**

--- a/src/treeSelect/__tests__/treeSelect.test.tsx
+++ b/src/treeSelect/__tests__/treeSelect.test.tsx
@@ -61,11 +61,16 @@ describe("Test treeSelect's fire functions", () => {
             },
         ];
         const { container } = render(
-            <TreeSelect treeData={treeData} getPopupContainer={(node) => node.parentNode} onSelect={fn} />
+            <TreeSelect
+                treeData={treeData}
+                treeDefaultExpandAll
+                getPopupContainer={(node) => node.parentNode}
+                onSelect={fn}
+            />
         );
 
         treeSelect.fireOpen(container);
-        treeSelect.fireSelect(container, 0);
+        treeSelect.fireSelect(container, 3);
         expect(fn).toBeCalled();
     });
 
@@ -101,5 +106,116 @@ describe("Test treeSelect's fire functions", () => {
         treeSelect.fireOpen(container);
         treeSelect.fireTreeExpand(container, 0);
         expect(fn).toBeCalled();
+    });
+
+    /**
+     * @link query
+     */
+    test('query', () => {
+        const { container, getByTestId } = render(
+            <>
+                <TreeSelect data-testid="tree1" />
+                <TreeSelect data-testid="tree2" />
+            </>
+        );
+        expect(treeSelect.query(container)).toBe(getByTestId('tree1'));
+        expect(treeSelect.query(container, 1)).toBe(getByTestId('tree2'));
+    });
+
+    /**
+     * @link queryInput
+     */
+    test('queryInput', () => {
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        const { container } = render(
+            <>
+                <TreeSelect onSearch={fn1} />
+                <TreeSelect showSearch onSearch={fn2} />
+            </>
+        );
+        treeSelect.fireSearch(treeSelect.queryInput(container)!, 'test1');
+        treeSelect.fireSearch(treeSelect.queryInput(container, 1)!, 'test2');
+        expect(fn1).toBeCalledWith('test1');
+        expect(fn2).toBeCalledWith('test2');
+    });
+
+    /**
+     * @link querySelector
+     */
+    test('querySelector', () => {
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        const { container } = render(
+            <>
+                <TreeSelect onDropdownVisibleChange={fn1} />
+                <TreeSelect onDropdownVisibleChange={fn2} />
+            </>
+        );
+        treeSelect.fireOpen(treeSelect.querySelector(container)!);
+        expect(fn1).toBeCalledTimes(1);
+        treeSelect.fireOpen(treeSelect.querySelector(container, 1)!);
+        expect(fn2).toBeCalledTimes(1);
+    });
+
+    /**
+     * @link queryDropdown
+     */
+    test('queryDropdown', () => {
+        const treeData = [
+            {
+                title: 'Node1',
+                value: '0-0',
+                children: [
+                    {
+                        title: 'Child Node1',
+                        value: '0-0-1',
+                    },
+                    {
+                        title: 'Child Node2',
+                        value: '0-0-2',
+                    },
+                ],
+            },
+        ];
+        const fn = jest.fn();
+        const { container } = render(<TreeSelect treeData={treeData} onSelect={fn} />);
+        treeSelect.fireOpen(treeSelect.querySelector(container)!);
+        treeSelect.fireSelect(treeSelect.queryDropdown(document)!, 0);
+        expect(fn).toBeCalledWith('0-0', expect.objectContaining({ title: 'Node1', value: '0-0' }));
+    });
+
+    /**
+     * @link queryOption
+     */
+    test('queryOption', () => {
+        const treeData = [
+            {
+                title: 'Node1',
+                value: '0-0',
+                children: [
+                    {
+                        title: 'Child Node1',
+                        value: '0-0-1',
+                    },
+                    {
+                        title: 'Child Node2',
+                        value: '0-0-2',
+                    },
+                ],
+            },
+        ];
+        const fn = jest.fn();
+        const { container } = render(
+            <TreeSelect
+                treeData={treeData}
+                getPopupContainer={(node) => node.parentNode}
+                treeDefaultExpandAll
+                onSelect={fn}
+            />
+        );
+        treeSelect.fireOpen(container);
+        treeSelect.fireSelect(treeSelect.queryOption(container, 2)!, 0);
+        expect(fn).toBeCalledWith('0-0-2', expect.objectContaining({ title: 'Child Node2', value: '0-0-2' }));
     });
 });

--- a/src/treeSelect/index.ts
+++ b/src/treeSelect/index.ts
@@ -2,14 +2,16 @@ import { fireEvent } from '@testing-library/react';
 
 import type { IContainer } from '../interface';
 import { getProvider } from '../provider';
-import { fireOpen as fireSelectOpen } from '../select';
 import { failedQuerySelector, queryViaSelector } from '../utils';
 
 /**
  * Fires onDropdownVisibleChange function
  */
 export function fireOpen(container: IContainer) {
-    fireSelectOpen(container);
+    const selector = `.${getProvider('prefixCls')}-tree-select .${getProvider('prefixCls')}-select-selector`;
+    const ele = querySelector(container);
+    if (!ele) throw failedQuerySelector(selector);
+    fireEvent.mouseDown(ele);
 }
 
 /**
@@ -24,6 +26,8 @@ export function fireSearch(container: IContainer, value: any) {
 
 /**
  * Fires onSelect function
+ *
+ * Need expand tree node first
  */
 export function fireSelect(container: IContainer, index: number) {
     const selector = `span.${getProvider('prefixCls')}-select-tree-node-content-wrapper`;
@@ -41,4 +45,70 @@ export function fireTreeExpand(container: IContainer, index: number) {
     const ele = container.querySelectorAll(selector).item(index)?.parentElement?.querySelector(switcher);
     if (!ele) throw failedQuerySelector(`${selector}[${index}]'s parentElement ${switcher}`);
     fireEvent.click(ele);
+}
+
+/**
+ * Returns the `index` element of TreeSelect
+ * @param index default is 0
+ */
+export function query(container: IContainer, index = 0) {
+    const selector = `.${getProvider('prefixCls')}-tree-select`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector, index);
+    return ele;
+}
+
+/**
+ * Returns the `index` element of Input inside TreeSelect
+ * @param index default is 0
+ */
+export function queryInput(container: IContainer, index = 0) {
+    const selector = `.${getProvider('prefixCls')}-tree-select input.${getProvider(
+        'prefixCls'
+    )}-select-selection-search-input`;
+    const ele = queryViaSelector<HTMLInputElement>(container, selector, index);
+    return ele;
+}
+
+/**
+ * Returns the `index` Selector dom inside Select,
+ * the main element to call fireOpen
+ * @param index default is 0
+ */
+export function querySelector(container: IContainer, index = 0) {
+    const selector = `.${getProvider('prefixCls')}-tree-select .${getProvider('prefixCls')}-select-selector`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector, index);
+    return ele;
+}
+
+/**
+ * Returns the Tree Select Dropdown which is not hidden
+ */
+export function queryDropdown(container: IContainer) {
+    const selector = `.${getProvider('prefixCls')}-tree-select-dropdown:not(.${getProvider(
+        'prefixCls'
+    )}-select-dropdown-hidden)`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector);
+    return ele;
+}
+
+/**
+ * Returns the `index` Option for Select
+ *
+ * Need expand tree node first
+ *
+ * @param index default is 0
+ */
+export function queryOption(container: IContainer, index = 0) {
+    const selector = `span.${getProvider('prefixCls')}-select-tree-node-content-wrapper`;
+    const ele = queryViaSelector<HTMLDivElement>(container, selector, index);
+    return ele;
+}
+
+/**
+ * Returns the `index` clear icon's container
+ */
+export function queryClear(container: IContainer, index = 0) {
+    const selector = `.${getProvider('prefixCls')}-tree-select .${getProvider('prefixCls')}-select-clear`;
+    const ele = queryViaSelector<HTMLSpanElement>(container, selector, index);
+    return ele;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ export const failedTriggerElement = () => new Error('Failed to trigger element f
  * 判断容器元素自身是否匹配选择器
  */
 export function queryViaSelector<T extends HTMLElement>(container: IContainer, selector: string, index?: number) {
+    if (!container) throw new Error('container element is null');
     if (!(container instanceof Document) && container.matches(selector)) {
         return container as T;
     }


### PR DESCRIPTION
由于弹出层元素会默认挂载在body下，打开多个下拉框后，无法精确定位到对应的弹出层下拉列表，所以所有弹出层组件改为只支持查询到当前展开状态的首个弹出层元素